### PR TITLE
Allow building with --std=gnu89

### DIFF
--- a/src/ulog.c
+++ b/src/ulog.c
@@ -62,7 +62,8 @@ void ulog_init() {
 // search the s_subscribers table to install or update fn
 ulog_err_t ulog_subscribe(ulog_function_t fn, ulog_level_t threshold) {
   int available_slot = -1;
-  for (int i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
+  int i;
+  for (i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
     if (s_subscribers[i].fn == fn) {
       // already subscribed: update threshold and return immediately.
       s_subscribers[i].threshold = threshold;
@@ -84,7 +85,8 @@ ulog_err_t ulog_subscribe(ulog_function_t fn, ulog_level_t threshold) {
 
 // search the s_subscribers table to remove
 ulog_err_t ulog_unsubscribe(ulog_function_t fn) {
-  for (int i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
+  int i;
+  for (i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
     if (s_subscribers[i].fn == fn) {
       s_subscribers[i].fn = NULL;    // mark as empty
       return ULOG_ERR_NONE;
@@ -108,11 +110,12 @@ const char *ulog_level_name(ulog_level_t severity) {
 
 void ulog_message(ulog_level_t severity, const char *fmt, ...) {
   va_list ap;
+  int i;
   va_start(ap, fmt);
   vsnprintf(s_message, ULOG_MAX_MESSAGE_LENGTH, fmt, ap);
   va_end(ap);
 
-  for (int i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
+  for (i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {
     if (s_subscribers[i].fn != NULL) {
       if (severity >= s_subscribers[i].threshold) {
         s_subscribers[i].fn(severity, s_message);


### PR DESCRIPTION
In my project I'm stuck with `--std=gnu89` to make this work  the only change needed is to define iterators at the beginning of block instead of in for loop.