### PR TITLE
If ULOG_ENABLED is undefined remove only logging functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,33 @@ void my_console_logger(ulog_level_t severity, const char *msg) {
 int main() {
     int arg = 42;
 
-    ULOG_INIT();
+ #ifdef ULOG_ENABLED
+    ulog_init();
 
     // log messages with a severity of WARNING or higher to the console.  The
     // user must supply a method for my_console_logger, e.g. along the lines
     // of what is shown above.
-    ULOG_SUBSCRIBE(my_console_logger, ULOG_WARNING_LEVEL);
+    ulog_subscribe(my_console_logger, ULOG_WARNING_LEVEL);
 
     // log messages with a severity of DEBUG or higher to a file.  The user must
     // provide a method for my_file_logger (not shown here).
-    ULOG_SUBSCRIBE(my_file_logger, ULOG_DEBUG_LEVEL);
+    ulog_subscribe(my_file_logger, ULOG_DEBUG_LEVEL);
+#endif
 
     ULOG_INFO("Info, arg=%d", arg);        // logs to file but not console
     ULOG_CRITICAL("Critical, arg=%d", arg);  // logs to file and console
 
+#ifdef ULOG_ENABLED
     // dynamically change the threshold for a specific logger
-    ULOG_SUBSCRIBE(my_console_logger, ULOG_INFO_LEVEL);
+    ulog_subscribe(my_console_logger, ULOG_INFO_LEVEL);
+#endif
 
     ULOG_INFO("Info, arg=%d", arg);          // logs to file and console
 
+#ifdef ULOG_ENABLED
     // remove a logger
-    ULOG_UNSUBSCRIBE(my_file_logger);
+    ulog_unsubscribe(my_file_logger);
+#endif
 
     ULOG_INFO("Info, arg=%d", arg);          // logs to console only
 }

--- a/src/ulog.h
+++ b/src/ulog.h
@@ -46,14 +46,16 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *     }
  *
  *     int main() {
- *         ULOG_INIT();
+ *     #ifdef ULOG_ENABLED
+ *         ulog_init();
  *
  *         // log to the console messages that are WARNING or more severe.  You
  *         // can re-subscribe at any point to change the severity level.
- *         ULOG_SUBSCRIBE(my_console_logger, ULOG_WARNING);
+ *         ulog_subscribe(my_console_logger, ULOG_WARNING);
  *
  *         // log to a file messages that are DEBUG or more severe
- *         ULOG_SUBSCRIBE(my_file_logger, ULOG_DEBUG);
+ *         ulog_subscribe(my_file_logger, ULOG_DEBUG);
+ *     #endif
  *
  *         int arg = 42;
  *         ULOG_INFO("Arg is %d", arg);  // logs to file but not console
@@ -86,13 +88,9 @@ typedef enum {
 // There are two ways to enable uLog: you can uncomment the following
 // line, or -- if it is commented out -- you can add -DULOG_ENABLED to
 // your compiler switches.
-#define ULOG_ENABLED
+//#define ULOG_ENABLED
 
 #ifdef ULOG_ENABLED
-  #define ULOG_INIT() ulog_init()
-  #define ULOG_SUBSCRIBE(a, b) ulog_subscribe(a, b)
-  #define ULOG_UNSUBSCRIBE(a) ulog_unsubscribe(a)
-  #define ulog_level_name(a) ulog_level_name(a)
   #define ULOG(...) ulog_message(__VA_ARGS__)
   #define ULOG_TRACE(...) ulog_message(ULOG_TRACE_LEVEL, __VA_ARGS__)
   #define ULOG_DEBUG(...) ulog_message(ULOG_DEBUG_LEVEL, __VA_ARGS__)
@@ -103,10 +101,6 @@ typedef enum {
   #define ULOG_ALWAYS(...) ulog_message(ULOG_ALWAYS_LEVEL, __VA_ARGS__)
 #else
   // uLog vanishes when disabled at compile time...
-  #define ULOG_INIT() do {} while(0)
-  #define ULOG_SUBSCRIBE(a, b) do {} while(0)
-  #define ULOG_UNSUBSCRIBE(a) do {} while(0)
-  #define ulog_level_name(a) do {} while(0)
   #define ULOG(s, f, ...) do {} while(0)
   #define ULOG_TRACE(f, ...) do {} while(0)
   #define ULOG_DEBUG(f, ...) do {} while(0)

--- a/tests/ulog_example.c
+++ b/tests/ulog_example.c
@@ -11,6 +11,7 @@
 // to ULOG.  This means you may print it or copy it, but saving a pointer to it
 // will lead to confusion and astonishment.
 //
+#ifdef ULOG_ENABLED
 void my_console_logger(ulog_level_t severity, char *msg)
 {
   printf("console: %s [%s]: %s\n",
@@ -26,32 +27,39 @@ void my_file_logger(ulog_level_t severity, char *msg)
          ulog_level_name(severity),
          msg);
 }
+#endif
 
 int main()
 {
   int arg = 42;
 
-  ULOG_INIT();
+#ifdef ULOG_ENABLED
+  ulog_init();
 
   // log messages with a severity of WARNING or higher to the console.  The
   // user must supply a method for my_console_logger, e.g. along the lines
   // of what is shown above.
-  ULOG_SUBSCRIBE(my_console_logger, ULOG_DEBUG_LEVEL);
+  ulog_subscribe(my_console_logger, ULOG_DEBUG_LEVEL);
 
   // log messages with a severity of DEBUG or higher to a file.  The user must
   // provide a method for my_file_logger (not shown here).
-  ULOG_SUBSCRIBE(my_file_logger, ULOG_WARNING_LEVEL);
+  ulog_subscribe(my_file_logger, ULOG_WARNING_LEVEL);
+#endif
 
   ULOG_INFO("Info, arg=%d", arg);         // logs to file but not console
   ULOG_CRITICAL("Critical, arg=%d", arg); // logs to file and console
 
+#ifdef ULOG_ENABLED
   // dynamically change the threshold for a specific logger
-  ULOG_SUBSCRIBE(my_console_logger, ULOG_INFO_LEVEL);
+  ulog_subscribe(my_console_logger, ULOG_INFO_LEVEL);
+#endif
 
   ULOG_INFO("Info, arg=%d", arg); // logs to file and console
 
+#ifdef ULOG_ENABLED
   // remove a logger
-  ULOG_UNSUBSCRIBE(my_file_logger);
+  ulog_unsubscribe(my_file_logger);
+#endif
 
   ULOG_INFO("Info, arg=%d", arg); // logs to console only
 }

--- a/tests/ulog_test.c
+++ b/tests/ulog_test.c
@@ -68,17 +68,17 @@ void logger_fn6(ulog_level_t severity, char *msg) {
 }
 
 void ulog_test() {
-  ULOG_INIT();
+  ulog_init();
   memset(fn_calls, 0, sizeof(fn_calls));
 
-  assert(ULOG_SUBSCRIBE(logger_fn0, ULOG_TRACE_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn1, ULOG_DEBUG_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn2, ULOG_INFO_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn3, ULOG_WARNING_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn4, ULOG_ERROR_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn5, ULOG_CRITICAL_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn0, ULOG_TRACE_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn1, ULOG_DEBUG_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn2, ULOG_INFO_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn3, ULOG_WARNING_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn4, ULOG_ERROR_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn5, ULOG_CRITICAL_LEVEL) == ULOG_ERR_NONE);
 
-  assert(ULOG_SUBSCRIBE(logger_fn6, ULOG_TRACE_LEVEL) == ULOG_ERR_SUBSCRIBERS_EXCEEDED);
+  assert(ulog_subscribe(logger_fn6, ULOG_TRACE_LEVEL) == ULOG_ERR_SUBSCRIBERS_EXCEEDED);
 
   ULOG_TRACE("Hello!");
   ULOG_DEBUG("Hello!");
@@ -108,14 +108,14 @@ void ulog_test() {
   // reset counters.  Test reassigning levels...
   memset(fn_calls, 0, sizeof(fn_calls));
 
-  assert(ULOG_SUBSCRIBE(logger_fn0, ULOG_CRITICAL_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn1, ULOG_ERROR_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn2, ULOG_WARNING_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn3, ULOG_INFO_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn4, ULOG_DEBUG_LEVEL) == ULOG_ERR_NONE);
-  assert(ULOG_SUBSCRIBE(logger_fn5, ULOG_TRACE_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn0, ULOG_CRITICAL_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn1, ULOG_ERROR_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn2, ULOG_WARNING_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn3, ULOG_INFO_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn4, ULOG_DEBUG_LEVEL) == ULOG_ERR_NONE);
+  assert(ulog_subscribe(logger_fn5, ULOG_TRACE_LEVEL) == ULOG_ERR_NONE);
 
-  assert(ULOG_SUBSCRIBE(logger_fn6, ULOG_TRACE_LEVEL) == ULOG_ERR_SUBSCRIBERS_EXCEEDED);
+  assert(ulog_subscribe(logger_fn6, ULOG_TRACE_LEVEL) == ULOG_ERR_SUBSCRIBERS_EXCEEDED);
 
   ULOG_TRACE("Hello!");
   ULOG_DEBUG("Hello!");
@@ -135,15 +135,15 @@ void ulog_test() {
   // reset counters.  Test unsubscribe
   memset(fn_calls, 0, sizeof(fn_calls));
 
-  assert(ULOG_UNSUBSCRIBE(logger_fn0) == ULOG_ERR_NONE);
-  assert(ULOG_UNSUBSCRIBE(logger_fn1) == ULOG_ERR_NONE);
-  assert(ULOG_UNSUBSCRIBE(logger_fn2) == ULOG_ERR_NONE);
-  assert(ULOG_UNSUBSCRIBE(logger_fn3) == ULOG_ERR_NONE);
-  assert(ULOG_UNSUBSCRIBE(logger_fn4) == ULOG_ERR_NONE);
+  assert(ulog_unsubscribe(logger_fn0) == ULOG_ERR_NONE);
+  assert(ulog_unsubscribe(logger_fn1) == ULOG_ERR_NONE);
+  assert(ulog_unsubscribe(logger_fn2) == ULOG_ERR_NONE);
+  assert(ulog_unsubscribe(logger_fn3) == ULOG_ERR_NONE);
+  assert(ulog_unsubscribe(logger_fn4) == ULOG_ERR_NONE);
   // leave logger_fn5 subscribed
-  // assert(ULOG_UNSUBSCRIBE(logger_fn5, ULOG_TRACE) == ULOG_ERR_NONE);
+  // assert(ulog_unsubscribe(logger_fn5, ULOG_TRACE) == ULOG_ERR_NONE);
 
-  assert(ULOG_UNSUBSCRIBE(logger_fn6) == ULOG_ERR_NOT_SUBSCRIBED);
+  assert(ulog_unsubscribe(logger_fn6) == ULOG_ERR_NOT_SUBSCRIBED);
 
   ULOG_TRACE("Hello!");
   ULOG_DEBUG("Hello!");


### PR DESCRIPTION
Removed only logging function if ULOG_ENABLED is undefined. Initialization and configuration are kept and may be disabled by the caller.