### PR TITLE
fixed example build,

### DIFF
--- a/src/ulog.h
+++ b/src/ulog.h
@@ -86,7 +86,7 @@ typedef enum {
 // There are two ways to enable uLog: you can uncomment the following
 // line, or -- if it is commented out -- you can add -DULOG_ENABLED to
 // your compiler switches.
-//#define ULOG_ENABLED
+#define ULOG_ENABLED
 
 #ifdef ULOG_ENABLED
   #define ULOG_INIT() ulog_init()

--- a/tests/ulog_example.c
+++ b/tests/ulog_example.c
@@ -15,7 +15,9 @@ void my_console_logger(ulog_level_t severity, char *msg)
 {
   printf("console: %s [%s]: %s\n",
          "time", // user defined function
-         ulog_level_name(severity),
+#if defined ULOG_ENABLED
+         ULOG_LEVEL_NAME(severity),
+#endif
          msg);
 }
 
@@ -23,7 +25,9 @@ void my_file_logger(ulog_level_t severity, char *msg)
 {
   printf("file: %s [%s]: %s\n",
          "time", // user defined function
-         ulog_level_name(severity),
+#if defined ULOG_ENABLED
+         ULOG_LEVEL_NAME(severity),
+#endif
          msg);
 }
 


### PR DESCRIPTION
If ULOG_ENABLED is not active at compile time, the macro ULOG_LEVEL_NAME expands to a do..while(0), which is not a suitable argument for printf call