### PR TITLE
Add option for a custom formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Some features of uLog:
 * uLog is easy to incorporate into nearly any environment, comprising one header file and one source file, and is written in pure C.
 * uLog provides familiar severity levels (CRITICAL, ERROR, WARNING, INFO, DEBUG, TRACE).
 * uLog supports multiple user-defined outputs (console, log file, in-memory buffer, etc), each with its own reporting threshold level.
-* uLog is "aggressively standalone" with minimal dependencies, requiring only stdio.h, string.h and stdarg.h.  
+* uLog is "aggressively standalone" with minimal dependencies, requiring just string.h, stdarg.h and only additionally stdio.h if you don't provide a custom formatter.
 * uLog gets out of your way when you're not using it: if ULOG_ENABLED is undefined at compile time, no logging code is generated.
 * uLog is well tested.  See the accompanying ulog_test.c file for details.
 
@@ -65,6 +65,26 @@ int main() {
     ULOG_INFO("Info, arg=%d", arg);          // logs to console only
 }
 ```
+
+## A custom formatter for uLog
+
+If `-DULOG_FORMATTER` is defined, uLog then tries to use `ulog_formatter()` with
+the same signature as `vsnprintf()` to format the output:
+
+``` c
+int ulog_formatter(char*, size_t, const char*, va_list);
+```
+
+For cases you wish to handroll the formatter yourself, or just want to use
+another `vsnprintf()` implementation by simply forwarding the arguments to it:
+
+``` c
+int ulog_formatter(char* buffer, size_t count, const char* format, va_list va) {
+  return vsnprintf_(buffer, count, format, va); // another vsnprintf impl.
+}
+```
+
+Otherwise uLog falls back to `vsnprintf()` from `<stdio.h>`.
 
 ## Questions?  Comments?  Improvements?
 

--- a/src/ulog.c
+++ b/src/ulog.c
@@ -33,9 +33,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifdef ULOG_ENABLED  // whole file...
 
-#include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#ifdef ULOG_FORMATTER
+extern int ulog_formatter(char*, size_t, const char*, va_list);
+#else
+#include <stdio.h>
+#endif
 
 
 // =============================================================================
@@ -124,7 +128,11 @@ void ulog_message(ulog_level_t severity, const char *fmt, ...) {
   va_list ap;
   int i;
   va_start(ap, fmt);
+#ifdef ULOG_FORMATTER
+  ulog_formatter(s_message, ULOG_MAX_MESSAGE_LENGTH, fmt, ap);
+#else
   vsnprintf(s_message, ULOG_MAX_MESSAGE_LENGTH, fmt, ap);
+#endif
   va_end(ap);
 
   for (i=0; i<ULOG_MAX_SUBSCRIBERS; i++) {


### PR DESCRIPTION
I figured it'd be nice to let the user to have the opt-in for choosing the `vsnprintf` implementation they see fit by adding a macro surrounding the single formatter call to `vsnprintf`.

The `vsnprintf` from stdio.h seems to be [not reentrant/malloc-free](https://www.nadler.com/embedded/newlibAndFreeRTOS.html) even when `configUSE_NEWLIB_REENTRANT` is set in the config and causes hard fault in my [benchmark code](https://github.com/znxuz/nucleo-f767zi/blob/5d669c5207b0b490cbe34994ceeefb235680b4ca/application/benchmark_tsink.cpp#L33) originally for another freertos lib, so that i couldn't even do the benchmark against the `vsnprintf` impl. from for example [printf.h](https://github.com/mpaland/printf) to present the results here.

But maybe with this addition the ulog could also claim that it would be reentrant when both the formatter and the logger for the formatted result are reentrant?